### PR TITLE
Some fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -157,21 +157,21 @@ class resolver (
   $bool_audit_only=any2bool($audit_only)
   $array_dns_servers = is_array($resolver::dns_servers) ? {
     false     => $resolver::dns_servers ? {
-      ''      => '',
+      ''      => [],
       default => split($resolver::dns_servers, ','),
     },
     default   => $resolver::dns_servers,
   }
   $array_search = is_array($resolver::search) ? {
     false     => $resolver::search ? {
-      ''      => '',
+      ''      => [],
       default => split($resolver::search, ','),
     },
     default   => $resolver::search,
   }
   $array_sortlist = is_array($resolver::sortlist) ? {
     false     => $resolver::sortlist ? {
-      ''      => '',
+      ''      => [],
       default => split($resolver::sortlist, ','),
     },
     default   => $resolver::sortlist,

--- a/spec/classes/resolver_spec.rb
+++ b/spec/classes/resolver_spec.rb
@@ -45,7 +45,7 @@ describe 'resolver' do
   end
 
   describe 'Test parameters as arrays' do
-    let(:params) { {:dns_domain => 'the_domain', :search => ['search1', 'search2'], :dns_servers => ['nameserver1', 'nameserver2'] } }
+    let(:params) { {:dns_domain => 'the_domain', :search => ['search1', 'search2'], :dns_servers => ['nameserver1', 'nameserver2'], :sortlist => ['sort1', 'sort2'] } }
 
     it 'should generate a valid template' do
       content = catalogue.resource('file', 'resolv.conf').send(:parameters)[:content]
@@ -53,6 +53,8 @@ describe 'resolver' do
       content.should match "search search1 search2"
       content.should match "nameserver nameserver1"
       content.should match "nameserver nameserver2"
+      content.should match "sortlist sort1 sort2"
+      content.should_not match "options"
     end
     it 'should not request a source' do
       content = catalogue.resource('file', 'resolv.conf').send(:parameters)[:source]
@@ -61,7 +63,7 @@ describe 'resolver' do
   end
 
   describe 'Test parameters as strings' do
-    let(:params) { {:dns_domain => 'the_domain', :search => 'search1,search2', :dns_servers => 'nameserver1,nameserver2' } }
+    let(:params) { {:dns_domain => 'the_domain', :search => 'search1,search2', :dns_servers => 'nameserver1,nameserver2', :sortlist => 'sort1,sort2' } }
 
     it 'should generate a valid template' do
       content = catalogue.resource('file', 'resolv.conf').send(:parameters)[:content]
@@ -69,6 +71,27 @@ describe 'resolver' do
       content.should match "search search1 search2"
       content.should match "nameserver nameserver1"
       content.should match "nameserver nameserver2"
+      content.should match "sortlist sort1 sort2"
+      content.should_not match "options"
+    end
+    it 'should not request a source' do
+      content = catalogue.resource('file', 'resolv.conf').send(:parameters)[:source]
+      content.should be_nil
+    end
+  end
+
+  describe 'Test options' do
+    let(:params) { {:dns_domain => 'the_domain', :dns_servers => 'server1', :options => { 'opt_a' => 'value_a', 'opt_b' => 'value_b', 'opt_c' => '' } } }
+
+    it 'should generate a valid template' do
+      content = catalogue.resource('file', 'resolv.conf').send(:parameters)[:content]
+      content.should match "domain the_domain"
+      content.should match "nameserver server1"
+      content.should match "options opt_a:value_a"
+      content.should match "options opt_b:value_b"
+      content.should match "options opt_c"
+      content.should_not match "search"
+      content.should_not match "sortlist"
     end
     it 'should not request a source' do
       content = catalogue.resource('file', 'resolv.conf').send(:parameters)[:source]

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -1,14 +1,16 @@
 # File Managed by Puppet
 domain <%= scope.lookupvar('resolver::dns_domain') %>
+<% if scope.lookupvar('resolver::array_search').length > 0 then -%>
 search <% scope.lookupvar('resolver::array_search').each do |src| %><%= src %> <% end %>
+<% end -%>
 <% scope.lookupvar('resolver::array_dns_servers').each do |ns| %>nameserver <%= ns %>
 <% end -%>
 
-<% if scope.lookupvar('resolver::array_sortlist') != :undefined and scope.lookupvar('resolver::array_sortlist') != '' then -%>
+<% if scope.lookupvar('resolver::array_sortlist').length > 0 then -%>
 sortlist <% scope.lookupvar('resolver::array_sortlist').each do |sl| %><%= sl %> <% end %>
 <% end -%>
 
-<% if scope.lookupvar('resolver::options') != :undefined and scope.lookupvar('resolver::array_options') != '' then -%>
+<% if scope.lookupvar('resolver::options').length > 0 then -%>
 <% scope.lookupvar('resolver::options').sort_by {|key, value| key}.each do |key, value| -%>
 options <%= key %><% if value != "" %>:<%= value %><% end %>
 <% end -%>


### PR DESCRIPTION
As discussed in pull request #1 (https://github.com/example42/puppet-resolver/pull/1), here are some new fixes.
I found a problem with the `options` parameter not being taken into account in the template.
And also, the `search` one which could not be empty.
